### PR TITLE
Add options to set useragent and peer id prefix.

### DIFF
--- a/luci/applications/luci-aria2/luasrc/model/cbi/aria2.lua
+++ b/luci/applications/luci-aria2/luasrc/model/cbi/aria2.lua
@@ -71,6 +71,8 @@ split=task:option(Value, "split", translate("Max number of split"))
 split.placeholder="5"
 save_session_interval=task:option(Value, "save_session_interval", translate("Autosave session interval"), translate("Sec"))
 save_session_interval.default="30"
+user_agent=task:option(Value, "user_agent", translate("User agent value"))
+user_agent.placeholder="aria2/1.18.7"
 
 bittorrent=m:section(TypedSection, "aria2", translate("BitTorrent Settings"))
 bittorrent.anonymous=true
@@ -91,6 +93,8 @@ bt_tracker_enable=bittorrent:option(Flag, "bt_tracker_enable", translate("Additi
 bt_tracker=bittorrent:option(DynamicList, "bt_tracker", translate("List of additional Bt tracker"))
 bt_tracker:depends("bt_tracker_enable", "1")
 bt_tracker.rmempty=true
+peer_id_prefix=bittorrent:option(Value, "peer_id_prefix", translate("Prefix of peer ID"))
+peer_id_prefix.placeholder="A2-1-18-7-"
 
 function bt_tracker.cfgvalue(self, section)
 	local rv = { }

--- a/luci/applications/luci-aria2/root/etc/init.d/aria2
+++ b/luci/applications/luci-aria2/root/etc/init.d/aria2
@@ -57,9 +57,15 @@ start_instance() {
 		max_overall_download_limit max_overall_upload_limit max_download_limit max_upload_limit max_concurrent_downloads \
 		max_connection_per_server min_split_size split save_session_interval follow_torrent listen_port bt_max_peers \
 		peer_id_prefix user_agent
-
+	
+	config_list_foreach "$s" extra_settings append_extrasettings
+	
 	SERVICE_UID="$user" \
 	service_start /usr/bin/aria2c --conf-path="$config_file"
+}
+
+append_extrasettings() {
+	echo "$1" >> $config_file
 }
 
 start() {

--- a/luci/applications/luci-aria2/root/etc/init.d/aria2
+++ b/luci/applications/luci-aria2/root/etc/init.d/aria2
@@ -5,6 +5,7 @@ START=99
 SERVICE_WRITE_PID=1
 SERVICE_DAEMONIZE=1
 
+
 append_params() {
 	local p; local v; local s="$1"; shift
 	for p in $*; do
@@ -54,7 +55,8 @@ start_instance() {
 	append_params "$s" \
 		file_allocation bt_enable_lpd enable_dht rpc_user rpc_passwd rpc_listen_port dir bt_tracker disk_cache \
 		max_overall_download_limit max_overall_upload_limit max_download_limit max_upload_limit max_concurrent_downloads \
-		max_connection_per_server min_split_size split save_session_interval follow_torrent listen_port bt_max_peers
+		max_connection_per_server min_split_size split save_session_interval follow_torrent listen_port bt_max_peers \
+		peer_id_prefix user_agent
 
 	SERVICE_UID="$user" \
 	service_start /usr/bin/aria2c --conf-path="$config_file"

--- a/luci/po/zh_CN/aria2.po
+++ b/luci/po/zh_CN/aria2.po
@@ -117,3 +117,9 @@ msgstr "RPC用户名"
 
 msgid "RPC password"
 msgstr "RPC密码"
+
+msgid "User agent value"
+msgstr "用户代理(UA)"
+
+msgid "Prefix of peer ID"
+msgstr "peer ID前缀"

--- a/luci/po/zh_CN/aria2.po
+++ b/luci/po/zh_CN/aria2.po
@@ -123,3 +123,9 @@ msgstr "用户代理(UA)"
 
 msgid "Prefix of peer ID"
 msgstr "peer ID前缀"
+
+"Extra Settings"
+"附加选项"
+
+"List of extra settings"
+"附加选项列表"


### PR DESCRIPTION
Add options to set user agent and peer id prefix. Useful for Private Tracker.

Update: add a extendable list to add even more custom options to aria2.conf.