### PR TITLE
Add button to show Json-RPC URL

### DIFF
--- a/luci/applications/luci-aria2/luasrc/model/cbi/aria2.lua
+++ b/luci/applications/luci-aria2/luasrc/model/cbi/aria2.lua
@@ -15,7 +15,7 @@ require("luci.util")
 require("luci.model.ipkg")
 
 --view jsonrpc
-local session = string.gsub(luci.sys.exec("cat /tmp/luci-sessions/* | md5sum | grep -oP \"[a-z0-9]*\""), "\n", "")
+local session = string.gsub(luci.sys.exec("(date|cut -c12-15;cat /tmp/luci-sessions/*)|md5sum|grep -oP \"[a-z0-9]*\""), "\n", "")
 local viewrpc = "cgi-bin/aria2rpcpath?" .. session
 local sessionbtn = "&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;<input type=\"button\" value=\" " .. translate("View Json-RPC URL") .. " \" onclick=\"window.open('/" .. viewrpc .. "')\"/>"
 

--- a/luci/applications/luci-aria2/luasrc/model/cbi/aria2.lua
+++ b/luci/applications/luci-aria2/luasrc/model/cbi/aria2.lua
@@ -42,8 +42,15 @@ local uci = require "luci.model.uci".cursor()
 local running = (luci.sys.call("pidof aria2c > /dev/null") == 0)
 local webinstalled = luci.model.ipkg.installed(webui) 
 local button = ""
+local openyaaw = "var curWwwPath=window.document.location.href;" ..
+"var pathName=window.document.location.pathname;" ..
+"var pos=curWwwPath.indexOf(pathName);" ..
+"var localhostPath=curWwwPath.substring(0, pos);" ..
+"var yaawpath=\"http:\"+localhostPath.substring(window.location.protocol.length)+\"/yaaw\";" ..
+"window.open(yaawpath)"
+
 if running and webinstalled then
-	button = "&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;<input type=\"button\" value=\" " .. translate("Open Web Interface") .. " \" onclick=\"window.open('/" .. webui .. "')\"/>"
+	button = "&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;<input type=\"button\" value=\" " .. translate("Open Web Interface") .. " \" onclick=\'" .. openyaaw .. "\'/>"
 end
 
 m = Map("aria2", translate("Aria2 Settings"), translate("Aria2 is a multi-protocol &amp; multi-source download utility, here you can configure the settings.") .. button .. sessionbtn .. aria2rpctxt)

--- a/luci/applications/luci-aria2/luasrc/model/cbi/aria2.lua
+++ b/luci/applications/luci-aria2/luasrc/model/cbi/aria2.lua
@@ -14,6 +14,12 @@ require("luci.sys")
 require("luci.util")
 require("luci.model.ipkg")
 
+--view jsonrpc
+local session = string.gsub(luci.sys.exec("cat /tmp/luci-sessions/* | md5sum | grep -oP \"[a-z0-9]*\""), "\n", "")
+local viewrpc = "cgi-bin/aria2rpcpath?" .. session
+local sessionbtn = "&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;<input type=\"button\" value=\" " .. translate("View Json-RPC URL") .. " \" onclick=\"window.open('/" .. viewrpc .. "')\"/>"
+
+
 local webui="yaaw"
 local uci = require "luci.model.uci".cursor()
 local running = (luci.sys.call("pidof aria2c > /dev/null") == 0)
@@ -23,7 +29,7 @@ if running and webinstalled then
 	button = "&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;<input type=\"button\" value=\" " .. translate("Open Web Interface") .. " \" onclick=\"window.open('/" .. webui .. "')\"/>"
 end
 
-m = Map("aria2", translate("Aria2 Settings"), translate("Aria2 is a multi-protocol &amp; multi-source download utility, here you can configure the settings.") .. button)
+m = Map("aria2", translate("Aria2 Settings"), translate("Aria2 is a multi-protocol &amp; multi-source download utility, here you can configure the settings.") .. button .. sessionbtn)
 
 s=m:section(TypedSection, "aria2", translate("Global settings"))
 s.addremove=false

--- a/luci/applications/luci-aria2/root/etc/init.d/aria2
+++ b/luci/applications/luci-aria2/root/etc/init.d/aria2
@@ -56,7 +56,7 @@ start_instance() {
 		file_allocation bt_enable_lpd enable_dht rpc_user rpc_passwd rpc_listen_port dir bt_tracker disk_cache \
 		max_overall_download_limit max_overall_upload_limit max_download_limit max_upload_limit max_concurrent_downloads \
 		max_connection_per_server min_split_size split save_session_interval follow_torrent listen_port bt_max_peers \
-		peer_id_prefix user_agent
+		peer_id_prefix user_agent rpc_secret
 	
 	config_list_foreach "$s" extra_settings append_extrasettings
 	

--- a/luci/applications/luci-aria2/root/www/cgi-bin/aria2rpcpath
+++ b/luci/applications/luci-aria2/root/www/cgi-bin/aria2rpcpath
@@ -2,7 +2,7 @@
 echo "Content-Type:text/plain"
 echo ""
 cd /tmp/luci-sessions
-if [ $QUERY_STRING = `cat /tmp/luci-sessions/* | md5sum | grep -oP "[a-z0-9]*"` ] ; then
+if [ $QUERY_STRING = `(date|cut -c12-15;cat /tmp/luci-sessions/*)|md5sum|grep -oP "[a-z0-9]*"` ] ; then
 
 echo http://\
 `uci get aria2.@aria2[0].rpc_user`\

--- a/luci/applications/luci-aria2/root/www/cgi-bin/aria2rpcpath
+++ b/luci/applications/luci-aria2/root/www/cgi-bin/aria2rpcpath
@@ -2,7 +2,7 @@
 echo "Content-Type:text/plain"
 echo ""
 cd /tmp/luci-sessions
-#if [ $QUERY_STRING = `(date|cut -c12-15;ls /tmp/luci-sessions/)|md5sum|grep -oP "[a-z0-9]*"` ] ; then
+if [ $QUERY_STRING = `(date|cut -c12-15;ls /tmp/luci-sessions/)|md5sum|grep -oP "[a-z0-9]*"` ] ; then
 	if [ `uci get aria2.@aria2[0].rpc_auth_method` = "user_pass" ] ; then
 echo http://\
 `uci get aria2.@aria2[0].rpc_user`\
@@ -21,4 +21,4 @@ echo http://\
 echo http://`uci get network.lan.ipaddr`:`uci get aria2.@aria2[0].rpc_listen_port 2>/dev/null || echo 6800`/jsonrpc
 		fi
 	fi
-#fi
+fi

--- a/luci/applications/luci-aria2/root/www/cgi-bin/aria2rpcpath
+++ b/luci/applications/luci-aria2/root/www/cgi-bin/aria2rpcpath
@@ -1,0 +1,14 @@
+#!/bin/sh
+echo "Content-Type:text/plain"
+echo ""
+cd /tmp/luci-sessions
+if [ $QUERY_STRING = `cat /tmp/luci-sessions/* | md5sum | grep -oP "[a-z0-9]*"` ] ; then
+
+echo http://\
+`uci get aria2.@aria2[0].rpc_user`\
+`uci get aria2.@aria2[0].rpc_auth_required 2&>1 >/dev/null && echo :`\
+`uci get aria2.@aria2[0].rpc_passwd`\
+`uci get aria2.@aria2[0].rpc_auth_required 2&>1 >/dev/null && echo @`\
+`uci get network.lan.ipaddr`:`uci get aria2.@aria2[0].rpc_listen_port 2>/dev/null || echo 6800`/jsonrpc
+
+fi

--- a/luci/applications/luci-aria2/root/www/cgi-bin/aria2rpcpath
+++ b/luci/applications/luci-aria2/root/www/cgi-bin/aria2rpcpath
@@ -2,13 +2,23 @@
 echo "Content-Type:text/plain"
 echo ""
 cd /tmp/luci-sessions
-if [ $QUERY_STRING = `(date|cut -c12-15;cat /tmp/luci-sessions/*)|md5sum|grep -oP "[a-z0-9]*"` ] ; then
-
+#if [ $QUERY_STRING = `(date|cut -c12-15;ls /tmp/luci-sessions/)|md5sum|grep -oP "[a-z0-9]*"` ] ; then
+	if [ `uci get aria2.@aria2[0].rpc_auth_method` = "user_pass" ] ; then
 echo http://\
 `uci get aria2.@aria2[0].rpc_user`\
-`uci get aria2.@aria2[0].rpc_auth_required 2&>1 >/dev/null && echo :`\
+":"\
 `uci get aria2.@aria2[0].rpc_passwd`\
-`uci get aria2.@aria2[0].rpc_auth_required 2&>1 >/dev/null && echo @`\
+"@"\
 `uci get network.lan.ipaddr`:`uci get aria2.@aria2[0].rpc_listen_port 2>/dev/null || echo 6800`/jsonrpc
-
-fi
+	else
+		if [ `uci get aria2.@aria2[0].rpc_auth_method` = "token" ] ; then
+echo http://\
+"token:"\
+`uci get aria2.@aria2[0].rpc_secret`\
+"@"\
+`uci get network.lan.ipaddr`:`uci get aria2.@aria2[0].rpc_listen_port 2>/dev/null || echo 6800`/jsonrpc
+		else
+echo http://`uci get network.lan.ipaddr`:`uci get aria2.@aria2[0].rpc_listen_port 2>/dev/null || echo 6800`/jsonrpc
+		fi
+	fi
+#fi

--- a/luci/po/zh_CN/aria2.po
+++ b/luci/po/zh_CN/aria2.po
@@ -129,3 +129,6 @@ msgstr "附加选项"
 
 msgid "List of extra settings"
 msgstr "附加选项列表"
+
+msgid "View Json-RPC URL"
+msgstr "查看 Json-RPC URL"

--- a/luci/po/zh_CN/aria2.po
+++ b/luci/po/zh_CN/aria2.po
@@ -109,9 +109,6 @@ msgstr "RPC设置"
 msgid "RPC port"
 msgstr "RPC端口"
 
-msgid "RPC authentication required"
-msgstr "启用RPC认证"
-
 msgid "RPC username"
 msgstr "RPC用户名"
 
@@ -132,3 +129,19 @@ msgstr "附加选项列表"
 
 msgid "View Json-RPC URL"
 msgstr "查看 Json-RPC URL"
+
+msgid "RPC authentication method"
+msgstr "RPC认证方式"
+
+msgid "No Authentication"
+msgstr "无认证"
+
+msgid "Username & Password"
+msgstr "用户名与密码"
+
+msgid "Token"
+msgstr "令牌"
+
+msgid "RPC Token"
+msgstr "RPC令牌"
+

--- a/packages/dnscrypt-proxy/Makefile
+++ b/packages/dnscrypt-proxy/Makefile
@@ -27,6 +27,7 @@ define Package/dnscrypt-proxy/default
   CATEGORY:=Network
   SUBMENU:=IP Addresses and Names
   URL:=http://dnscrypt.org/
+  DEPENDS:=+libsodium
   MAINTAINER:=nanpuyue <nanpuyue@gmail.com>
 endef
 


### PR DESCRIPTION
增加一个按钮，按下后文本框自动显示jsonrpc的路径。悬停自动选中。
jsonrpc的路径由cgi脚本生成。
cgi脚本有简单的验证，根据/tmp/luci-sessions/下文件是否改变以及页面未更新时间是否超过十分钟来判断
增加rpc认证方式的选择，可选择无认证，用户名密码认证，令牌认证三种
以https访问luci时，总是把yaaw地址修改为http（https下无法直接使用yaaw）
dnscrypt-proxy不添加libsodium为依赖时编译出错
其他 杂项修改